### PR TITLE
MPI operator container args

### DIFF
--- a/chart/templates/_mpi.tpl
+++ b/chart/templates/_mpi.tpl
@@ -8,4 +8,5 @@ mpi:
     url: "{{.Values.mpi.registry.url}}"
     user: "{{.Values.mpi.registry.user}}"
     password: "{{.Values.mpi.registry.password}}"
+  addlArgs: {{.Values.mpi.addlArgs}}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -331,6 +331,7 @@ mpi:
     url: "docker.io"
     user: ""
     password: ""
+  addlArgs: []
 
 cnvrgApp:
   replicas: 1

--- a/roles/common/tasks/install.yml
+++ b/roles/common/tasks/install.yml
@@ -17,7 +17,7 @@
       dest: "{{ dumpDir }}/{{ templatePath.replace('/','_') }}"
     when: dumpDir != ""
 
-  # Set default value of "no" for K8S wait moduel,when wait_to_complete is not defined
+  # Set default value of "no" for K8S wait module, when wait_to_complete is not defined
   # https://docs.ansible.com/ansible/latest/collections/community/kubernetes/k8s_module.html#parameter-wait
   - name: Set wait flag
     set_fact:

--- a/roles/mpi/tasks/main.yml
+++ b/roles/mpi/tasks/main.yml
@@ -17,7 +17,7 @@
       loop: "{{crds}}"
       when: state == "present"
 
-    - name: Install MPI resrouces
+    - name: Install MPI resources
       include_role:
         name: common
         tasks_from: install
@@ -36,4 +36,3 @@
         state: "present"
       loop: "{{crds}}"
       when: state == "absent"
-

--- a/roles/mpi/templates/mpi/mpi.yml
+++ b/roles/mpi/templates/mpi/mpi.yml
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks:False
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -158,14 +159,14 @@ spec:
 {% endif %}
       containers:
       - name: mpi-operator
-        image: "{{mpi.image}}"
-        args: [
-          "-alsologtostderr",
-          "--kubectl-delivery-image",
-          "{{ mpi.kubectlDeliveryImage }}",
-          "--lock-namespace",
-          "{{ansible_operator_meta.namespace}}",
-          "--namespace",
-          "{{ ansible_operator_meta.namespace }}"
-        ]
+        image: "{{ mpi.image }}"
+        args:
+        - "-alsologtostderr"
+        - "--kubectl-delivery-image"
+        - "{{ mpi.kubectlDeliveryImage }}"
+        - "--lock-namespace"
+        - "{{ ansible_operator_meta.namespace }}"
+        - "--namespace"
+        - "{{ ansible_operator_meta.namespace }}"{% for mpiArg in mpi.addlArgs %}{% for arg in mpiArg.split() %}
+        - "{{ arg | trim }}"{% endfor %}{% endfor %}
         imagePullPolicy: Always

--- a/roles/mpi/vars/main.yml
+++ b/roles/mpi/vars/main.yml
@@ -8,3 +8,4 @@ mpi:
     url: "docker.io"
     user: ""
     password: ""
+  addlArgs: []


### PR DESCRIPTION
This PR allows users to pass additional arguments into mpi-operator container via a new block in the values.yaml under the "mpi" section.

Open to feedback and suggestions.